### PR TITLE
Use more-normal safetyCharts path in Remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     gsm.app=gilead-biostats/gsm.app@dev,
-    safetyCharts=url::https://safetygraphics.r-universe.dev/src/contrib/safetyCharts_0.4.0.tar.gz
+    safetyCharts=SafetyGraphics/safetyCharts
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
I think this was just this way to work around a shinyapps.io bug a while back.